### PR TITLE
Make sure decimal data can be sent as JSON

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     jsonschema>=2.0,<3
     requests>=2.11.1,<3
     enum34>=1.1.6,<2
+    simplejson>=3.10.0,<4
 
 [options.packages.find]
 exclude = tests, tests.*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from decimal import Decimal
+
 import pytest
 from mock import Mock
 
@@ -48,8 +50,8 @@ def complex_shipment():
         }]),
         parcels=Parcels([{
             "copies": 1,
-            "weight": 2,
-            "volume": 3,
+            "weight": Decimal("1.23"),
+            "volume": Decimal("45.6"),
             "contents": "Stuff",
             "valuePerParcel": True,
             "dangerousGoods": {
@@ -58,7 +60,7 @@ def complex_shipment():
                 "packageCode": "I",
                 "description": "Dangerous stuff",
                 "adrClass": "1",
-                "netWeight": 12,
+                "netWeight": Decimal("1.23"),
                 "trCode": "E"
             },
         }]),

--- a/tests/test_shipments.py
+++ b/tests/test_shipments.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from decimal import Decimal
+
+from requests.compat import json
+
 
 class TestShipment(object):
     def test_shipment_builds(self, simple_shipment):
@@ -81,8 +85,8 @@ class TestShipment(object):
                 'parcels': [
                     {
                         'copies': 1,
-                        'weight': 2,
-                        'volume': 3,
+                        'weight': Decimal('1.23'),
+                        'volume': Decimal('45.6'),
                         'contents': 'Stuff',
                         'valuePerParcel': True,
                         'dangerousGoods': {
@@ -91,7 +95,7 @@ class TestShipment(object):
                             'packageCode': 'I',
                             'description': 'Dangerous stuff',
                             'adrClass': '1',
-                            'netWeight': 12,
+                            'netWeight': Decimal('1.23'),
                             'trCode': 'E'
                         },
                     }
@@ -103,3 +107,10 @@ class TestShipment(object):
                 }
             }
         }
+
+    def test_complex_shipment_serializes(self, complex_shipment):
+        """
+        Test that requests can send data with Decimal values.
+        """
+        complex_shipment.build()
+        json.dumps(complex_shipment.data)


### PR DESCRIPTION
Require the simplejson library for requests to add Decimal serialization support.