### PR TITLE
Release under MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2018 Anders Innovations
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,11 +9,13 @@ maintainer = Anders Innovations
 maintainer_email = support@anders.fi
 url = https://github.com/andersinno/smartship
 download_url = https://github.com/andersinno/smartship/releases
-license= ?????
+license = MIT
+license_file = LICENSE
 keywords = smartship, posti
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
@@ -21,7 +23,6 @@ classifiers =
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
-    Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]


### PR DESCRIPTION
Add LICENSE file which contains the text of MIT license and update the
license info in setup.cfg.

Also update other package meta information in setup.cfg, namely
Development status from Alpha to Stable and remove CPython as this is
not CPython specific library.