### PR TITLE
README: Fix ReST formatting

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,9 @@
 SmartShip Change Log
 ====================
 
+* Fix README formatting so that it is valid ReST
+
+
 1.1.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,7 @@ Locations
 As the above agents method is a paid service we also provide an interface to the Posti location service API.
 
 .. code:: python
+
     from smartship.carriers.posti import get_locations
     locations = get_locations(country_code="FI", zipcode="00120")
 


### PR DESCRIPTION
Checked with:

    pip install readme_renderer
    python setup.py check --restructuredtext --strict

which reported the following:

    warning: Check: The project's long_description has invalid markup
    which will not be rendered on PyPI. The following syntax errors were
    detected:

    line 142: Error: Error in "code" directive:

    maximum 1 argument(s) allowed, 9 supplied.

    .. code:: python
        from smartship.carriers.posti import get_locations
        locations = get_locations(country_code="FI", zipcode="00120")